### PR TITLE
5 課題が追加されたときに対象の学生に通知を送信するように実装

### DIFF
--- a/public/homework/add_homework.php
+++ b/public/homework/add_homework.php
@@ -1,4 +1,7 @@
 <?php
+
+use Application\UseCases\ClassUseCase;
+use Application\UseCases\UserUseCase;
 header("Access-Control-Allow-Origin: *");
 header("Access-Control-Allow-Methods: POST, OPTIONS");
 header("Access-Control-Allow-Headers: Content-Type, Authorization");
@@ -11,11 +14,11 @@ use Helpers\ApiKeyValidator;
 use Infrastructure\Persistence\MySQLHomeworkRepository;
 use Infrastructure\Persistence\MySQLUserRepository;
 use Infrastructure\Persistence\MySQLClassRepository;
+use Helpers\NotificationHandler;
 
-
-ini_set('display_errors', 1);
-ini_set('display_startup_errors', 1);
-error_reporting(E_ALL);
+ini_set('display_errors', 0);
+// ini_set('display_startup_errors', 1);
+// error_reporting(E_ALL);
 
 if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
     http_response_code(200);
@@ -23,10 +26,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
 }
 
 if (!in_array($_SERVER['REQUEST_METHOD'], ['POST'])) {
-    Response::send('error', 'Method not allowed. Use UPDATE', 405);
+    Response::send('error', 'Method not allowed. Use POST', 405);
 }
-
-$headers = getallheaders();
 
 // API Key validation
 $headers = getallheaders();
@@ -67,7 +68,12 @@ if ($title == null || !is_string($title)) {
     Response::send('error', '無効なタイトル形式です。', 400);
 }
 
-$due_date = new DateTimeImmutable($due_date);
+try {
+    $due_date = $due_date ? new DateTimeImmutable($due_date) : null;
+} catch (Exception $e) {
+    Response::send('error', '無効な締め切り日形式です。', 400);
+}
+
 if ($due_date == null || !($due_date instanceof DateTimeImmutable)) {
     Response::send('error', '無効な締め切り日形式です。', 400);
 }
@@ -79,7 +85,14 @@ try {
     $userRepository = new MySQLUserRepository($connection);
     $classRepository = new MySQLClassRepository($connection);
 
+    $classUseCase = new ClassUseCase($classRepository, $userRepository);
+    $userUseCase = new UserUseCase($userRepository);
     $homeworkUseCase = new HomeworkUseCase($homeworkRepository, $userRepository, $classRepository);
+
+    // NotificationHandlerの初期化
+    $notificationHandler = new NotificationHandler(FIREBASE_PROJECT_ID, FIREBASE_SERVICE_ACCOUNT_PATH);
+
+
     $newHomework = Homework::createNew(
         $teacher_id,
         $class_id,
@@ -88,8 +101,37 @@ try {
         $due_date
     );
 
+    // 宿題を追加
     $homeworkUseCase->add($newHomework);
-    Response::send('success', '宿題の追加が成功しました。', 200);
+
+    // クラス情報を取得
+    $classToNotify = $classUseCase->findById($class_id);
+
+    // 通知対象のユーザーを取得
+    $usersToNotify = $userUseCase->findByMajorCodeAndAdmissionYear($classToNotify->majorCode, $classToNotify->admissionYear);
+
+    $errorsSendingNotifications = [];
+    // 対象のユーザーに通知を送信
+    foreach ($usersToNotify as $user) {
+        if ($user->fcmToken) {
+            $response = $notificationHandler->sendFCMNotification(
+                $user->fcmToken,
+                '新しい宿題が追加されました',
+                "{$classToNotify->name}に{$newHomework->title}の宿題が追加されました。",
+                $newHomework->id
+            );
+            if ($response['code'] !== 200) {
+                $errorsSendingNotifications[] = "学生番号: {$user->studentCode}, レスポンス: {$response['response']}";
+            }
+        }
+    }
+
+    if (!empty($errorsSendingNotifications)) {
+        // エラーログを出力
+        Response::send('error', '宿題の追加が成功しましたが、一部の通知の送信に失敗しました。', 200, json_encode($errorsSendingNotifications));
+    } else {
+        Response::send('success', '宿題の追加が成功しました。', 200, json_encode($usersToNotify));
+    }
 
 } catch (Throwable $e) {
     Response::send('error', $e->getMessage(), 500);

--- a/src/Helpers/NotificationHandler.php
+++ b/src/Helpers/NotificationHandler.php
@@ -18,8 +18,22 @@ class NotificationHandler
         }
     }
 
-
-    function sendFCMNotification($fcmToken, $title, $body)
+    /**
+     * Firebase Cloud Messaging (FCM) を使用して、特定の課題情報を含むプッシュ通知を送信するメソッド。
+     *
+     * このメソッドは、指定されたデバイストークン（$fcmToken）に対して、
+     * タイトル（$title）、本文（$body）、および課題ID（$homeworkID）を含む通知を送信します。
+     * iOS・Android 双方で動作し、通知をタップした際に対象の課題詳細画面へ遷移できるように
+     * `data` フィールドに課題IDを含めて送信します。
+     *
+     * @param string $fcmToken 通知を送信する対象デバイスの FCM トークン
+     * @param string $title 通知タイトル
+     * @param string $body 通知本文
+     * @param string $homeworkID 対象の課題を識別するID（アプリ側で画面遷移に使用）
+     * @return array レスポンス内容と HTTP ステータスコードを含む連想配列
+     *               ['response' => string, 'code' => int]
+     * @throws \Exception CURL 実行時にエラーが発生した場合に例外をスローします
+     */
     function sendFCMNotification($fcmToken, $title, $body, $homeworkID)
     {
         $projectId = $this->firebaseProjectID;

--- a/src/Helpers/NotificationHandler.php
+++ b/src/Helpers/NotificationHandler.php
@@ -5,12 +5,12 @@ namespace Helpers;
 
 class NotificationHandler
 {
-    public string $projectID; // Firebase Project ID
+    public string $firebaseProjectID; // Firebase Project ID
     public string $keyFilePath; // service-account.json のパス
 
-    public function __construct(string $projectID, string $keyFilePath = __DIR__ . '/../../config/service-account.json')
+    public function __construct(string $firebaseProjectID, string $keyFilePath = __DIR__ . '/../../config/service-account.json')
     {
-        $this->projectID = $projectID;
+        $this->firebaseProjectID = $firebaseProjectID;
         $this->keyFilePath = $keyFilePath;
 
         if ($this->keyFilePath === false || !file_exists($this->keyFilePath)) {
@@ -21,7 +21,7 @@ class NotificationHandler
 
     function sendFCMNotification($fcmToken, $title, $body)
     {
-        $projectId = $this->projectID;
+        $projectId = $this->firebaseProjectID;
         $keyFilePath = $this->keyFilePath;
 
         // Step 1: Get OAuth 2.0 access token

--- a/src/Helpers/NotificationHandler.php
+++ b/src/Helpers/NotificationHandler.php
@@ -20,6 +20,7 @@ class NotificationHandler
 
 
     function sendFCMNotification($fcmToken, $title, $body)
+    function sendFCMNotification($fcmToken, $title, $body, $homeworkID)
     {
         $projectId = $this->firebaseProjectID;
         $keyFilePath = $this->keyFilePath;
@@ -37,6 +38,9 @@ class NotificationHandler
                 'notification' => [
                     'title' => $title,
                     'body' => $body
+                ],
+                'data' => [
+                    'homeworkId' => $homeworkID
                 ],
                 'android' => [
                     'priority' => 'high'


### PR DESCRIPTION
## Close #5

このプルリクエストでは、宿題追加処理にプッシュ通知機能を追加し、API内のエラーハンドリングを改善しました。主な変更点は、Firebase Cloud Messaging（FCM）を用いた通知機能の統合、日付解析時のエラー処理改善、コードおよびコメントの整理です。

---

### 🔔 通知機能の統合

* `add_homework.php` 内で `NotificationHandler` を初期化・利用し、新しい宿題が追加された際に FCM プッシュ通知を送信するようにしました。
  クラス情報に基づき、該当する全ユーザーに通知が送信されるようになっています。
  通知には宿題の詳細が含まれ、ユーザーは通知から直接宿題詳細画面へ遷移する機能の実装ができるようになりました。

* `NotificationHandler.php` を更新し、通知データペイロードに宿題IDを含める機能を追加しました。
  これにより、クライアント側で通知タップ時に対象の宿題詳細画面へ直接遷移する機能の実装ができるようになりました。
---

### ⚙️ エラーハンドリングとバリデーション

* `due_date` フィールドのパース処理を `try-catch` ブロックで囲み、無効な日付形式に対してより明確なエラーメッセージを返すよう改善しました。

---

### 🧹 コードおよびコメントの改善

* `add_homework.php` のエラーレポート設定を更新し、本番環境ではエラーを表示しないように変更しました。
* サポートされていない HTTP メソッドに対するエラーメッセージを修正しました。
* 新しいクラスやヘルパーの `use` ステートメントを追加しました。