### PR TITLE
12 （サーバー側）fcmToeknを削除する endpointを作成

### DIFF
--- a/public/user/delete_fcm_token.php
+++ b/public/user/delete_fcm_token.php
@@ -1,0 +1,68 @@
+<?php
+
+use Application\UseCases\FCMTokenUseCase;
+use Domain\Entities\FCMToken;
+use Helpers\ApiKeyValidator;
+use Helpers\Response;
+use Infrastructure\Persistence\MySQLFCMTokenRepository;
+use Infrastructure\Persistence\MySQLUserRepository;
+
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+ini_set('display_errors', 1);
+ini_set('display_startup_errors', 1);
+error_reporting(E_ALL);
+
+if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
+    http_response_code(200);
+    exit();
+}
+
+if (!in_array($_SERVER['REQUEST_METHOD'], ['DELETE'])) {
+    Response::send('error', 'Method not allowed. Use DELETE', 405);
+}
+
+
+// API Key validation
+$headers = getallheaders();
+$clientApiKey = $headers['Authorization'] ?? $headers['authorization'] ?? null;
+ApiKeyValidator::check($clientApiKey);
+
+// Expected JSON structure
+// {
+// user_id: String,
+// device_id: String,
+// }
+
+$input = json_decode(file_get_contents('php://input'), true);
+if (json_last_error() !== JSON_ERROR_NONE) {
+    Response::send('error', '無効なJSONデータです。', 400);
+}
+
+$userID = $input['user_id'] ?? null;
+$deviceID = $input['device_id'] ?? null;
+if (!isset($userID)) {
+    Response::send('error', 'ユーザーIDは必須です。', 400);
+}
+
+if (!isset($deviceID)) {
+    Response::send('error', 'デバイスIDは必須です。', 400);
+}
+
+
+try {
+    $connection = new mysqli(DB_HOST, DB_USER, DB_PASS, DB_NAME);
+    $fcmTokenRepository = new MySQLFCMTokenRepository($connection);
+    $userRepository = new MySQLUserRepository($connection);
+    $fcmUseCase = new FCMTokenUseCase($fcmTokenRepository, $userRepository);
+
+    $fcmUseCase->deleteFCMToken($userID, $deviceID);
+
+    Response::send('success', 'FCMトークンが正常に削除されました。', 200);
+} catch (InvalidArgumentException $e) {
+    Response::send('error', 'エラーが発生しました。' . $e->getMessage(), 400);
+} catch (Throwable $e) {
+    Response::send('error', '予期しないエラーが発生しました。' . $e->getMessage(), 500);
+}
+

--- a/src/Application/UseCases/FCMTokenUseCase.php
+++ b/src/Application/UseCases/FCMTokenUseCase.php
@@ -4,6 +4,8 @@ namespace Application\UseCases;
 use Domain\Entities\FCMToken;
 use Domain\Repositories\FCMTokenRepositoryInterface;
 use Domain\Repositories\UserRepositoryInterface;
+use Exception;
+use InvalidArgumentException;
 
 
 class FCMTokenUseCase
@@ -28,10 +30,9 @@ class FCMTokenUseCase
     ) {
 
         // Userの存在をチェック
-        $userInDB = $this->userRepository->findById($userID);
-
-        if (!$userInDB) {
-            throw new \Exception("指定されたユーザーは存在しません : " . $userID);
+        $userExist = $this->userExists($userID);
+        if (!$userExist) {
+            throw new Exception("Userが存在しません。" . $userID);
         }
 
         $fcmTokenInDB = $this->fcmTokenRepository->findByUserIdAndDeviceId($userID, $deviceID);
@@ -57,6 +58,35 @@ class FCMTokenUseCase
     public function getTokensByUserId(string $userID): array
     {
         return $this->fcmTokenRepository->findByUserId($userID);
+    }
+
+
+    public function deleteFCMToken(string $userID, string $deviceID): void
+    {
+        // Userの存在をチェック
+        if (!$this->userExists($userID)) {
+            throw new InvalidArgumentException("Userが存在しません。" . $userID);
+        }
+        // FCMトークンの存在をチェック
+        if (!$this->fcmTokenExists($userID, $deviceID)) {
+            throw new InvalidArgumentException("FCMトークンが存在しません。" . $userID . ", " . $deviceID);
+        }
+
+        $this->fcmTokenRepository->deleteFCMToken($userID, $deviceID);
+    }
+
+
+    private function userExists(string $userID): bool
+    {
+        $user = $this->userRepository->findById($userID);
+        return $user !== null;
+    }
+
+
+    private function fcmTokenExists(string $userID, string $deviceID): bool
+    {
+        $fcmToken = $this->fcmTokenRepository->findByUserIdAndDeviceId($userID, $deviceID);
+        return $fcmToken !== null;
     }
 
 

--- a/src/Domain/Repositories/FCMTokenRepositoryInterface.php
+++ b/src/Domain/Repositories/FCMTokenRepositoryInterface.php
@@ -9,5 +9,6 @@ interface FCMTokenRepositoryInterface
     public function updateFCMToken(string $userID, string $deviceID, string $newFCMToken): void;
     public function findByUserIdAndDeviceId(string $userId, string $deviceId): ?FCMToken;
     public function findByUserId(string $userId): array;
+    public function deleteFCMToken(string $userId, string $deviceId): void;
 }
 

--- a/src/Infrastructure/Persistence/MySQLFCMTokenRepository.php
+++ b/src/Infrastructure/Persistence/MySQLFCMTokenRepository.php
@@ -83,6 +83,17 @@ class MySQLFCMTokenRepository implements FCMTokenRepositoryInterface
     }
 
 
+    public function deleteFCMToken(string $userId, string $deviceId): void
+    {
+        $query = "DELETE FROM fcm_tokens WHERE user_id = ? AND device_id = ?";
+        $types = "ss";
+        $params = [$userId, $deviceId];
+        $error_message = "FCMトークンの削除に失敗しました。";
+
+        $this->executeQuery($query, $types, $params, $error_message);
+    }
+
+
 
     private function executeQuery(
         string $query,


### PR DESCRIPTION
close #12 
このプルリクエストは、特定デバイスに紐づくユーザーのFCMトークン削除機能をAPIエンドポイント・ユースケース・リポジトリの各層で実装し、バリデーションやエラーハンドリングも強化した内容です。

### 主な実装ポイント
- 新規APIエンドポイント `public/user/delete_fcm_token.php` を追加し、ID・APIキーのバリデーションと構造化エラーレスポンス対応のDELETE処理を実装。
- `FCMTokenUseCase` に `deleteFCMToken` を追加、ユーザーとトークンの存在チェックをprivateメソッドに分離して例外処理を整理。
- `FCMTokenRepositoryInterface` へ `deleteFCMToken` を追加し、`MySQLFCMTokenRepository` でSQL DELETEクエリの実装とエラーハンドリングを反映。

### トークン削除のベストプラクティス
- FCMトークンは端末ごとに紐付いており、不要・期限切れ・無効なトークンは都度サーバーDBから削除することで、通知失敗や無駄な送信を防ぐことが推奨されています。
- 削除APIには適切なユーザー認証やキー検証、削除時の詳細なエラー返却が現場でも重要となります。

端末単位・ユーザー単位での柔軟なプッシュ通知制御・管理の土台となる堅牢な実装です。