### PR TITLE
17 [Server] fcm-tokenで通知送信したときに NotRegisteredや InvalidRegisteration になるトークンを削除する

### DIFF
--- a/public/homework/add_homework.php
+++ b/public/homework/add_homework.php
@@ -1,6 +1,7 @@
 <?php
 
 use Application\UseCases\ClassUseCase;
+use Application\UseCases\NotificationUseCase;
 use Application\UseCases\UserUseCase;
 use Application\UseCases\FCMTokenUseCase;
 header("Access-Control-Allow-Origin: *");
@@ -92,9 +93,10 @@ try {
     $userUseCase = new UserUseCase($userRepository);
     $homeworkUseCase = new HomeworkUseCase($homeworkRepository, $userRepository, $classRepository);
     $fcmTokenUseCase = new FCMTokenUseCase($fcmTokenRepository, $userRepository);
-
+    
     // NotificationHandlerの初期化
     $notificationHandler = new NotificationHandler(FIREBASE_PROJECT_ID, FIREBASE_SERVICE_ACCOUNT_PATH);
+    $notificationUseCase = new NotificationUseCase($notificationHandler, $fcmTokenUseCase);
 
 
     $newHomework = Homework::createNew(
@@ -113,43 +115,16 @@ try {
 
     // 通知対象のユーザーを取得
     $usersToNotify = $userUseCase->findByMajorCodeAndAdmissionYear($classToNotify->majorCode, $classToNotify->admissionYear);
-
-    $errorsSendingNotifications = [];
-    // 対象のユーザーに通知を送信
-    foreach ($usersToNotify as $user) {
-        // ユーザーの全てのFCMトークンを取得
-        $fcmTokens = $fcmTokenUseCase->getTokensByUserId($user->id);
-        
-        foreach ($fcmTokens as $fcmTokenEntity) {
-            if ($fcmTokenEntity->fcmToken) {
-                $response = $notificationHandler->sendFCMNotification(
-                    $fcmTokenEntity->fcmToken,
-                    '新しい宿題が追加されました',
-                    "{$classToNotify->name}に{$newHomework->title}の宿題が追加されました。",
-                    $newHomework->id
-                );
-                if ($response['code'] !== 200) {
-                    $errorsSendingNotifications[] = "学生番号: {$user->studentCode}, デバイスID: {$fcmTokenEntity->deviceId}, レスポンス: {$response['response']}";
-
-                    // 無効なトークンの場合は削除
-                    if ($response['code'] === 410 || $response['code'] === 404 || $response['code'] === 400) {
-                        try {
-                            $fcmTokenUseCase->deleteFCMToken($user->id, $fcmTokenEntity->deviceId);
-                        } catch (Throwable $e) {
-                            $errorsSendingNotifications[] = "無効なFcmTokenの削除に失敗しました。学生番号: {$user->studentCode}, デバイスID: {$fcmTokenEntity->deviceId}, エラー: {$e->getMessage()}";
-                        }
-                    }
-                }
-            }
+    foreach($usersToNotify as $user) {
+        $body = $classToNotify->name."に".$newHomework->title."が追加されました。";
+        $invalidTokens = $notificationUseCase->sendNotification($user->id, "新しい宿題が追加されました: ",$body, $newHomework->id);
+        if (!empty($invalidTokens)) {
+            Response::send('success', '課題は正常に追加されましたが、一部の学生への通知は失敗しました。', 200, json_encode($invalidTokens));
         }
     }
-
-    if (!empty($errorsSendingNotifications)) {
-        // エラーログを出力
-        Response::send('error', '宿題の追加が成功しましたが、一部の通知の送信に失敗しました。', 200, json_encode($errorsSendingNotifications));
-    } else {
-        Response::send('success', '宿題の追加が成功しました。', 200, json_encode($usersToNotify));
-    }
+    
+    Response::send('success', '宿題の追加が成功しました。', 200, json_encode($usersToNotify));
+    
 
 } catch (Throwable $e) {
     Response::send('error', $e->getMessage(), 500);

--- a/public/homework/add_homework.php
+++ b/public/homework/add_homework.php
@@ -130,6 +130,15 @@ try {
                 );
                 if ($response['code'] !== 200) {
                     $errorsSendingNotifications[] = "学生番号: {$user->studentCode}, デバイスID: {$fcmTokenEntity->deviceId}, レスポンス: {$response['response']}";
+
+                    // 無効なトークンの場合は削除
+                    if ($response['code'] === 410 || $response['code'] === 404 || $response['code'] === 400) {
+                        try {
+                            $fcmTokenUseCase->deleteFCMToken($user->id, $fcmTokenEntity->deviceId);
+                        } catch (Throwable $e) {
+                            $errorsSendingNotifications[] = "無効なFcmTokenの削除に失敗しました。学生番号: {$user->studentCode}, デバイスID: {$fcmTokenEntity->deviceId}, エラー: {$e->getMessage()}";
+                        }
+                    }
                 }
             }
         }

--- a/src/Application/UseCases/FCMTokenUseCase.php
+++ b/src/Application/UseCases/FCMTokenUseCase.php
@@ -55,6 +55,9 @@ class FCMTokenUseCase
     }
 
 
+    /**
+     * @return FCMToken[]
+     */
     public function getTokensByUserId(string $userID): array
     {
         return $this->fcmTokenRepository->findByUserId($userID);

--- a/src/Application/UseCases/NotificationUseCase.php
+++ b/src/Application/UseCases/NotificationUseCase.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Application\UseCases;
+
+use Domain\Entities\FCMToken;
+use Helpers\NotificationHandler;
+
+class NotificationUseCase
+{
+    private NotificationHandler $notificationHandler;
+    private FCMTokenUseCase $fCMTokenUseCase;
+
+    public function __construct(NotificationHandler $notificationHandler, FCMTokenUseCase $fCMTokenUseCase)
+    {
+        $this->notificationHandler = $notificationHandler;
+        $this->fCMTokenUseCase = $fCMTokenUseCase;
+    }
+
+    /**
+     * @return FCMToken[]
+     */
+    public function sendNotification(string $userID, string $title, string $body, string $homeworkID): array
+    {
+        // 無効なトークンを格納する配列
+        $invalidTokens = [];
+
+        $fcmTokens = $this->fCMTokenUseCase->getTokensByUserId($userID);
+
+        foreach ($fcmTokens as $token) {
+
+            try {
+                $response = $this->notificationHandler->sendFCMNotification($token->fcmToken, $title, $body, $homeworkID);
+                if (!$response) {
+                    $invalidTokens[] = $token;
+                }
+
+                $responseCode = $response['code'] ?? null;
+                if (in_array($responseCode, [400, 404, 410], true)) {
+                    $invalidTokens[] = $token;
+                }
+            } catch (\Exception $e) {
+                $invalidTokens = $fcmTokens;
+            }
+        }
+
+         // 無効なトークンを削除
+        $this->deleteInvalidTokens($invalidTokens);
+
+        return $invalidTokens;
+    }
+
+
+    /**
+     * 無効なトークンを削除する
+     *
+     * @param FCMToken[] $tokens
+     * @return void
+     */
+    private function deleteInvalidTokens(array $tokens): void
+    {
+        foreach ($tokens as $token) {
+            $this->fCMTokenUseCase->deleteFCMToken($token->userId, $token->deviceId);
+        }
+    }
+}

--- a/src/Infrastructure/Persistence/MySQLFCMTokenRepository.php
+++ b/src/Infrastructure/Persistence/MySQLFCMTokenRepository.php
@@ -66,6 +66,9 @@ class MySQLFCMTokenRepository implements FCMTokenRepositoryInterface
     }
 
 
+    /**
+     * @return FCMToken[]
+     */
     public function findByUserId(string $userId): array
     {
         $query = "SELECT * FROM fcm_tokens WHERE user_id = ?";


### PR DESCRIPTION
close #17 
このプルリクエストでは、新しい宿題登録時の通知ロジックをリファクタリングし、通知処理とトークン管理をカプセル化する`NotificationUseCase`を導入しました。  
主な目的はコードのモジュール化、エラー処理の強化、および無効なFCMトークンの削除を改善することです。  
通知送信処理はコントローラロジックから抽象化され、コードベースがよりクリーンかつ保守性の高いものになりました。

### 通知処理のリファクタリング

- 通知送信および無効なFCMトークンの削除を担当する`NotificationUseCase`クラスを新規追加し、関連ロジックを集中管理することで関心の分離を改善しました。（`src/Application/UseCases/NotificationUseCase.php`）
- `add_homework.php`で直接`NotificationHandler`を呼び出したりトークンを手動で処理する代わりに、`NotificationUseCase`を利用するように修正しました。（`public/homework/add_homework.php`）

### FCMトークン管理

- FCMトークン取得メソッドに型アノテーションを追加し、可読性と静的解析性を向上させました。（`src/Application/UseCases/FCMTokenUseCase.php`, `src/Infrastructure/Persistence/MySQLFCMTokenRepository.php`）

### コードベースのクリーンアップ

- `add_homework.php`から冗長なエラー処理や通知ロジックを削除し、新しいユースケースに処理を委譲することで、メンテナンス性と可読性を高めました。（`public/homework/add_homework.php`）

### 依存関係の管理

- 新しい通知フローを実現するために、`NotificationUseCase`のインポートを`add_homework.php`に追加しました。（`public/homework/add_homework.php`）