### PR TITLE
3 クラスの編集のEndpoint作成

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ config/
 
 curltest.txt
 /vendor/
+
+.vscode/

--- a/public/class/update_class.php
+++ b/public/class/update_class.php
@@ -1,0 +1,104 @@
+<?php
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Helpers\Response;
+use Helpers\ApiKeyValidator;
+use Application\UseCases\ClassUseCase;
+use Domain\Entities\ClassEntity;
+use Infrastructure\Persistence\MySQLClassRepository;
+use Infrastructure\Persistence\MySQLUserRepository;
+
+header("Access-Control-Allow-Origin: *");
+header("Access-Control-Allow-Methods: GET, OPTIONS");
+header("Access-Control-Allow-Headers: Content-Type, Authorization");
+
+
+
+
+if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
+    http_response_code(200);
+    exit();
+}
+ if (!in_array($_SERVER['REQUEST_METHOD'], ['UPDATE'])) {
+    Response::send('error', 'Method not allowed. Use UPDATE', 405);
+}
+
+$headers = getallheaders();
+// API Key validation
+$clientApiKey = $headers['Authorization'] ?? $headers['authorization'] ?? null;
+ApiKeyValidator::checkTeacherKey($clientApiKey);
+
+// Expected JSON structure
+// {
+// id: String,
+// name: String,
+// teacher_id: String,
+// admission_year: Integer,
+// major_code: String
+// }
+
+
+$input = json_decode(file_get_contents('php://input'), true);
+
+if (json_last_error() !== JSON_ERROR_NONE) {
+    Response::send('error', '無効なJSONデータです。', 400);
+}
+
+$id = $input['id'] ?? null;
+$name = $input['name'] ?? null;
+$admission_year = $input['admission_year'] ?? null;
+$major_code = $input['major_code'] ?? null;
+$teacher_id = $input['teacher_id'] ?? null;
+
+if (!isset($id)) {
+    Response::send('error', 'クラスIDは必須です。', 400);
+}
+
+if (!isset($name)) {
+    Response::send('error', '授業名は必須です。', 400);
+}
+if ($name == null || !is_string($name)) {
+    Response::send('error', '無効な学科名形式です。', 400);
+}
+
+if (!isset($teacher_id)) {
+    Response::send('error', '教師IDは必須です。', 400);
+}
+
+if ($teacher_id == null || !is_string($teacher_id)) {
+    Response::send('error', '無効な教師ID形式です。', 400);
+}
+
+if (!isset($admission_year)) {
+    Response::send('error', '入学年度は必須です。', 400);
+}
+if ($admission_year == null || !is_int($admission_year)) {
+    Response::send('error', '無効な入学年度形式です。', 400);
+}
+if (!isset($major_code)) {
+    Response::send('error', '専攻のコードは必須です。', 400);
+}
+if ($major_code == null || !is_string($major_code)) {
+    Response::send('error', '無効な専攻のコード形式です。', 400);
+}
+
+
+try {
+    $connection = new mysqli(DB_HOST, DB_USER, DB_PASS, DB_NAME);
+    $classRepository = new MySQLClassRepository($connection);
+    $userRepository = new MySQLUserRepository($connection);
+    $classUseCase = new ClassUseCase($classRepository, $userRepository);
+
+    $classToUpdate = ClassEntity::createNew(
+        id: $id,
+        teacher_id: $teacher_id,
+        name: $name,
+        admissionYear: $admission_year,
+        majorCode: $major_code
+    );
+
+    $classUseCase->updateClass($classToUpdate);
+    Response::send('success', 'クラス情報が更新されました。', 200);
+} catch (Throwable $e) {
+    Response::send('error', $e->getMessage(), 500);
+}

--- a/src/Application/UseCases/ClassUseCase.php
+++ b/src/Application/UseCases/ClassUseCase.php
@@ -65,6 +65,22 @@ class ClassUseCase
         return $this->classRepository->findByTeacherId($teacherId);
     }
 
+
+
+    public function updateClass(ClassEntity $updatedClass): void
+    {
+        $existingClass = $this->classRepository->findById($updatedClass->id);
+        if ($existingClass === null) {
+            throw new \InvalidArgumentException("指定されたIDのクラスが存在しません。");
+        }
+
+
+        $this->validateClass($updatedClass);
+
+        // Update the class
+        $this->classRepository->update($updatedClass);
+    }
+
     private function isTeacher(string $userId): bool
     {
         $user = $this->userRepository->findById($userId);
@@ -73,11 +89,6 @@ class ClassUseCase
 
     private function validateClass(ClassEntity $class): void
     {
-        $classInDb = $this->classRepository->findById($class->id);
-        if ($classInDb !== null) {
-            throw new \InvalidArgumentException("指定されたIDのクラスは既に存在します。");
-        }
-
         if (empty($class->id) || empty($class->name) || empty($class->admissionYear) || empty($class->majorCode)) {
             throw new \InvalidArgumentException("Classの全てのフィールドは必須です。");
         }

--- a/src/Domain/Entities/ClassEntity.php
+++ b/src/Domain/Entities/ClassEntity.php
@@ -45,10 +45,16 @@ class ClassEntity implements JsonSerializable
         string $teacher_id,
         string $name,
         int $admissionYear,
-        string $majorCode
+        string $majorCode,
+        ?string $id = null
     ): self {
+        
+        if($id === null) {
+            $id = bin2hex(random_bytes(16));
+        }
+
         return new self(
-            bin2hex(random_bytes(16)),
+            $id,
             $teacher_id,
             $name,
             $admissionYear,

--- a/src/Domain/Repositories/ClassRepositoryInterface.php
+++ b/src/Domain/Repositories/ClassRepositoryInterface.php
@@ -9,4 +9,5 @@ interface ClassRepositoryInterface
     public function findById(string $id): ?ClassEntity;
     public function findByTeacherId(string $teacherId): array;
     public function findByMajorCodeAndAdmissionYear(string $majorCode, int $admissionYear): array;
+    public function update(ClassEntity $class): void;
 }

--- a/src/Infrastructure/Persistence/MySQLClassRepository.php
+++ b/src/Infrastructure/Persistence/MySQLClassRepository.php
@@ -79,6 +79,16 @@ class MySQLClassRepository implements ClassRepositoryInterface
     }
 
 
+    public function update(ClassEntity $class): void
+    {
+        $query = "UPDATE classes SET teacher_id = ?, name = ?, admission_year = ?, major_code = ? WHERE id = ?";
+        $types = 'ssiss';
+        $params = [$class->teacher_id, $class->name, $class->admissionYear, $class->majorCode, $class->id];
+        $errorMessage = 'Classの更新に失敗しました。';
+        $this->executeQuery($query, $types, $params, $errorMessage);
+    }
+
+
     private function executeQuery(
         string $query,
         string $types,
@@ -87,7 +97,6 @@ class MySQLClassRepository implements ClassRepositoryInterface
     ): mysqli_result|bool {
 
         $stmt = $this->connection->prepare($query);
-
         if ($stmt === false) {
             throw new \RuntimeException('ステートメントの準備に失敗しました。詳細: ' . $this->connection->error);
         }


### PR DESCRIPTION
close #3 
このプルリクエストでは、システム内のクラス情報を更新する機能を追加しました。主な変更点は、クラス情報の更新を扱うエンドポイントの追加、アプリケーション層への更新ロジックの実装、リポジトリ層での更新処理のサポートです。さらに、`ClassEntity`のコンストラクタがオプションIDを扱えるよう改良され、関連インターフェース定義も更新されています。

**API・エンドポイントの変更**

- クラス情報の更新を扱う新たなエンドポイント`public/class/update_class.php`を追加しました。リクエストのバリデーション、APIキーの確認、レスポンス処理も含みます。

**アプリケーション層の強化**

- `ClassUseCase`に`updateClass`メソッドを実装し、クラスの存在確認を行ってから更新処理を実施するようにしました。
- `validateClass`内の重複したID存在チェックを削除し、これを`updateClass`で対応する形にリファクタリングしました。

**ドメイン・リポジトリの更新**

- `ClassEntity::createNew`がオプションの`id`パラメータを受け付けるようになり、ID未指定時は新規IDを生成する仕様に変更しました。
- クラスエンティティの更新処理を定義するため、`ClassRepositoryInterface`に`update`メソッドを追加しました。
- クラスレコードのDB更新を行う`update`メソッドを`MySQLClassRepository`に実装しました。